### PR TITLE
[document] fix tags examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This collection provides action plugins to manipulate the Quay API.
           tags:
             - v17
             - v18
+          remove_tags:
+            - v16
           sync_interval: 604800  # 1 week
           robot_account: myrobot
           sync_now: true

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ This collection provides action plugins to manipulate the Quay API.
         visibility: public
         mirror:
           from: ghcr.io/foo/bar
-          tags: v17,v18
+          tags:
+            - v17
+            - v18
           sync_interval: 604800  # 1 week
           robot_account: myrobot
           sync_now: true


### PR DESCRIPTION
Maybe it worked as well with a comma separated string (I doubt). But it's better to have an example that use the right type for tags.

I take the occasion to add an example for the new options remove_tags introduced 0.0.9.